### PR TITLE
Release Logging Feature Merge

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -15,11 +15,12 @@
  *******************************************************************/
 
 using CornellPad.Services.Interfaces;
+using MetroLog;
+using Microsoft.Extensions.Logging;
 
 namespace CornellPad;
 
 // TODO: A 'print-to-PDF' feature would be a huge boon to users; QuestPDF is a great choice here.
-// TODO: Adding logging, even in release, is a necessity. We can't ask the user to provide technical crash information.
 
 /// <summary>
 /// Enumerates the four valid theme settings for CornellPad.
@@ -55,14 +56,45 @@ public enum CornellPadTheme
 public partial class App : Application
 {
     private readonly IDataService _dataService;
+    private readonly ILogger<App> _logger;
+
     private ResourceDictionary _styleThemeDictionary;
+
     private CornellPadTheme _currentTheme;
 
-    public App(IDataService dataService)
+    public App(IDataService dataService, ILogger<App> logger)
     {
         InitializeComponent();
 
-        _dataService = dataService;
+        if (logger != null)
+            _logger = logger;
+        else
+        {
+            #region debug_logger
+#if DEBUG
+            Debug.WriteLine("Null exception in App constructor: ILogger<App>");
+#endif
+            #endregion
+
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (dataService != null)
+            _dataService = dataService;
+        else
+        {
+            #region debug_dataservice
+
+#if DEBUG
+            Debug.WriteLine("Null exception in App constructor: IDataService");
+#elif !DEBUG
+            _logger.LogCritical("Null exception in App constructor: IDataService");
+#endif
+
+            #endregion
+
+            throw new ArgumentNullException(nameof(dataService));
+        }
 
         // New mapper for the Entry control
         Microsoft.Maui.Handlers.EntryHandler.Mapper.AppendToMapping(nameof(Entry), (handler, view) =>

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Logging;
 
 namespace CornellPad;
 
+// TODO: Change the License headers in the source files; Digital Brain Lice isn't the owner of the code base, CornellPad is.
 // TODO: A 'print-to-PDF' feature would be a huge boon to users; QuestPDF is a great choice here.
 
 /// <summary>

--- a/CornellPad.csproj
+++ b/CornellPad.csproj
@@ -85,6 +85,7 @@
 		<PackageReference Include="CommunityToolkit.Maui" Version="6.1.0" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
 		<PackageReference Include="MauiDynamicUnderlineControls" Version="1.2.0" />
+		<PackageReference Include="MetroLog.Maui" Version="2.1.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
 		<PackageReference Include="sqlite-net-pcl" Version="1.8.116" />
 		<PackageReference Include="SQLiteNetExtensions" Version="2.1.0" />

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -18,6 +18,7 @@ using CommunityToolkit.Maui;
 using CornellPad.Popups;
 using CornellPad.Services;
 using CornellPad.Services.Interfaces;
+using MetroLog.MicrosoftExtensions;
 using Microsoft.Extensions.Logging;
 
 namespace CornellPad;
@@ -46,10 +47,25 @@ public static class MauiProgram
                 fonts.AddFont("SourceSans3-Bold.ttf", "SourceSansPro_Bold");
                 fonts.AddFont("SourceSans3-Regular.ttf", "SourceSansPro_Regular");
             });
-
+        /////////////////////////////////////
+        // Debugging Service Registrations
+        /////////////////////////////////////
 #if DEBUG
-		builder.Logging.AddDebug();
+        // For DEBUG, we'll just use the MAUI default...
+        builder.Logging.AddDebug();
+#elif !DEBUG
+        // ...but for release, we'll use MetroLog.
+        builder.Logging
+            .SetMinimumLevel(LogLevel.Warning)
+            .AddStreamingFileLogger(options =>
+            {
+                options.RetainDays = 2;
+                options.FolderPath = Path.Combine(
+                    FileSystem.CacheDirectory,
+                    "CornellPadLogs");
+            });
 #endif
+
         /////////////////////////////////////
         // Dependency Service Registrations
         /////////////////////////////////////

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -53,8 +53,8 @@ public static class MauiProgram
 #if DEBUG
         // For DEBUG, we'll just use the MAUI default...
         builder.Logging.AddDebug();
-#elif !DEBUG
-        // ...but for release, we'll use MetroLog.
+#endif
+        // ...but we'll include MetroLog no matter what.
         builder.Logging
             .SetMinimumLevel(LogLevel.Warning)
             .AddStreamingFileLogger(options =>
@@ -64,7 +64,7 @@ public static class MauiProgram
                     FileSystem.CacheDirectory,
                     "CornellPadLogs");
             });
-#endif
+
 
         /////////////////////////////////////
         // Dependency Service Registrations

--- a/Services/SQLiteDataService.cs
+++ b/Services/SQLiteDataService.cs
@@ -29,7 +29,18 @@ public class SQLiteDataService : IDataService
 
     public SQLiteDataService(ILogger<SQLiteDataService> logger)
     {
-        _logger = logger;
+        if (logger != null)
+            _logger = logger;
+        else
+        {
+            #region debug_logger
+#if DEBUG
+            Debug.WriteLine("Null exception in NoteViewModel constructor: ILogger<NoteViewModel>");
+#endif
+            #endregion
+
+            throw new ArgumentNullException(nameof(logger));
+        }
 
         if (_connection is null)
             Init();

--- a/Services/SQLiteDataService.cs
+++ b/Services/SQLiteDataService.cs
@@ -15,6 +15,8 @@
  *******************************************************************/
 
 using CornellPad.Services.Interfaces;
+using MetroLog;
+using Microsoft.Extensions.Logging;
 using SQLiteNetExtensions.Extensions;
 using System.Linq.Expressions;
 
@@ -23,9 +25,12 @@ namespace CornellPad.Services;
 public class SQLiteDataService : IDataService
 {
     SQLiteConnection _connection;
+    private readonly ILogger<SQLiteDataService> _logger;
 
-    public SQLiteDataService()
+    public SQLiteDataService(ILogger<SQLiteDataService> logger)
     {
+        _logger = logger;
+
         if (_connection is null)
             Init();
     }
@@ -106,7 +111,7 @@ public class SQLiteDataService : IDataService
 #if DEBUG
             Debug.WriteLine(inserted == 1 ? "Success" : "Failure", "'System.ArgumentOutOfRangeException' handled. The SettingsModel was created");
 #endif
-            #endregion
+#endregion
         }
 
         // We must have at least one library, so the user can immediately start using the app.
@@ -132,7 +137,7 @@ public class SQLiteDataService : IDataService
 #if DEBUG
             Debug.WriteLine((inserted == 1 && updated == 1) ? "Success" : "Failure", "'System.ArgumentOutOfRangeException' handled. 'default' library was created and setting were updated");
 #endif
-            #endregion
+#endregion
         }
     }
 
@@ -203,6 +208,8 @@ public class SQLiteDataService : IDataService
         {
 #if DEBUG
             Debug.WriteLine(e.Message);
+#elif !DEBUG
+            _logger.LogError("Set PRAGMA cache_size Exception Message: {message}\n    Stack Trace: {trace}", e.Message, e.StackTrace);
 #endif
         }
     }
@@ -229,6 +236,8 @@ public class SQLiteDataService : IDataService
         {
 #if DEBUG
             Debug.WriteLine(e.Message);
+#elif !DEBUG
+            _logger.LogError("Set PRAGMA page_size Exception Message: {message}\n    Stack Trace: {trace}", e.Message, e.StackTrace);
 #endif
         }
     }
@@ -257,6 +266,8 @@ public class SQLiteDataService : IDataService
         {
 #if DEBUG
             Debug.WriteLine(e.Message);
+#elif !DEBUG
+            _logger.LogError("Set PRAGMA locking_mode Exception Message: {message}\n    Stack Trace: {trace}", e.Message, e.StackTrace);
 #endif
         }
     }
@@ -283,6 +294,8 @@ public class SQLiteDataService : IDataService
         {
 #if DEBUG
             Debug.WriteLine(e.Message);
+#elif !DEBUG
+            _logger.LogError("Set PRAGMA temp_store Exception Message: {message}\n    Stack Trace: {trace}", e.Message, e.StackTrace);
 #endif
         }
     }
@@ -306,6 +319,8 @@ public class SQLiteDataService : IDataService
         {
 #if DEBUG
             Debug.WriteLine(e.Message);
+#elif !DEBUG
+            _logger.LogError("Set PRAGMA auto_vacuum Exception Message: {message}\n    Stack Trace: {trace}", e.Message, e.StackTrace);
 #endif
         }
     }

--- a/ViewModels/CreateLibraryViewModel.cs
+++ b/ViewModels/CreateLibraryViewModel.cs
@@ -15,6 +15,8 @@
  *******************************************************************/
 
 using CornellPad.Services.Interfaces;
+using MetroLog;
+using Microsoft.Extensions.Logging;
 
 namespace CornellPad.ViewModels;
 
@@ -24,6 +26,8 @@ public partial class CreateLibraryViewModel : BaseViewModel
     // Members & Member Mutators
     /////////////////////////////////////////////////////////////////////////////////
     private IDataService _dataService;
+    private readonly ILogger<CreateLibraryViewModel> _logger;
+
     private LibraryViewModel _libraryViewModel;
     private string _name;
     private string _description;
@@ -87,9 +91,38 @@ public partial class CreateLibraryViewModel : BaseViewModel
     /////////////////////////////////////////////////////////////////////////////////
     // Methods
     /////////////////////////////////////////////////////////////////////////////////
-    public CreateLibraryViewModel(IDataService dataService, LibraryViewModel libraryViewModel)
+    public CreateLibraryViewModel(IDataService dataService, LibraryViewModel libraryViewModel, ILogger<CreateLibraryViewModel> logger)
     {
-        _dataService = dataService;
+        if (logger != null)
+            _logger = logger;
+        else
+        {
+            #region debug_logger
+#if DEBUG
+            Debug.WriteLine("Null exception in CreateLibraryViewModel constructor: ILogger<CreateLibraryViewModel>");
+#endif
+            #endregion
+
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (dataService != null)
+            _dataService = dataService;
+        else
+        {
+            #region debug_dataservice
+
+#if DEBUG
+            Debug.WriteLine("Null exception in CreateLibraryViewModel constructor: IDataService");
+#elif !DEBUG
+            _logger.LogCritical("Null exception in CreateLibraryViewModel constructor: IDataService");
+#endif
+
+            #endregion
+
+            throw new ArgumentNullException(nameof(dataService));
+        }
+
         _libraryViewModel = libraryViewModel;
 
         IsButtonEnabled = false;

--- a/ViewModels/DeleteLibraryViewModel.cs
+++ b/ViewModels/DeleteLibraryViewModel.cs
@@ -16,6 +16,8 @@
 
 using CommunityToolkit.Maui.Core;
 using CornellPad.Services.Interfaces;
+using MetroLog;
+using Microsoft.Extensions.Logging;
 
 namespace CornellPad.ViewModels;
 
@@ -26,6 +28,7 @@ public partial class DeleteLibraryViewModel : BaseViewModel
     /////////////////////////////////////////////////////////////////////////////////
     private IDataService _dataService;
     private IPopupService _popupService;
+    private readonly ILogger<DeleteLibraryViewModel> _logger;
 
     //public ObservableCollection<LibraryModel> Libraries { get; set; }
 
@@ -44,10 +47,54 @@ public partial class DeleteLibraryViewModel : BaseViewModel
     /////////////////////////////////////////////////////////////////////////////////
     // Methods
     /////////////////////////////////////////////////////////////////////////////////
-    public DeleteLibraryViewModel(IDataService dataService, IPopupService popupService)
+    public DeleteLibraryViewModel(IDataService dataService, IPopupService popupService, ILogger<DeleteLibraryViewModel> logger)
     {
-        _dataService = dataService;
-        _popupService = popupService;
+        if (logger != null)
+            _logger = logger;
+        else
+        {
+            #region debug_logger
+#if DEBUG
+            Debug.WriteLine("Null exception in DeleteLibraryViewModel constructor: ILogger<DeleteLibraryViewModel>");
+#endif
+            #endregion
+
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (dataService != null)
+            _dataService = dataService;
+        else
+        {
+            #region debug_dataservice
+
+#if DEBUG
+            Debug.WriteLine("Null exception in DeleteLibraryViewModel constructor: IDataService");
+#elif !DEBUG
+            _logger.LogCritical("Null exception in DeleteLibraryViewModel constructor: IDataService");
+#endif
+
+            #endregion
+
+            throw new ArgumentNullException(nameof(dataService));
+        }
+
+        if (popupService != null)
+            _popupService = popupService;
+        else
+        {
+            #region debug_popupservice
+
+#if DEBUG
+            Debug.WriteLine("Null exception in DeleteLibraryViewModel constructor: IPopupService");
+#elif !DEBUG
+            _logger.LogCritical("Null exception in DeleteLibraryViewModel constructor: IPopupService");
+#endif
+
+            #endregion
+
+            throw new ArgumentNullException(nameof(popupService));
+        }
 
         SelectedLibraryModel = _dataService.ReadLibraries().Where(lib => lib.Id == _dataService.ReadSettings().CurrentLibraryId).ToList()[0];
 

--- a/ViewModels/LibraryViewModel.cs
+++ b/ViewModels/LibraryViewModel.cs
@@ -101,14 +101,14 @@ public partial class LibraryViewModel : BaseViewModel, IQueryAttributable
 
             if (libraryList is null)
             {
-                Console.WriteLine("Error: libraryList is null. Can't continue.");
+                _logger.LogCritical("Null exception in LibraryViewModel constructor: {var}", nameof(libraryList));
                 return;
             }
 
             if (libraryList.Count > 1)
             {
                 // We have more than one library, but neither matches the settings 'currentLibraryId'.
-                Console.WriteLine("Warning: No found libraries ID values match ID for currently selected library. Setting current library to first found libraries ID value.");
+                _logger.LogWarning("No found library ID values match ID for currently selected library. Setting current library to first found libraries ID value.");
             }
 
 

--- a/ViewModels/LibraryViewModel.cs
+++ b/ViewModels/LibraryViewModel.cs
@@ -16,6 +16,8 @@
 
 using CommunityToolkit.Maui.Core;
 using CornellPad.Services.Interfaces;
+using MetroLog;
+using Microsoft.Extensions.Logging;
 
 namespace CornellPad.ViewModels;
 
@@ -29,6 +31,7 @@ public partial class LibraryViewModel : BaseViewModel, IQueryAttributable
     private readonly IDataService _dataService;
 
     private readonly IPopupService _popupService;
+    private readonly ILogger<LibraryViewModel> _logger;
 
     /// <summary>
     /// 'Back Button' navs result in duplicate TopicModel creates without this bool.
@@ -41,8 +44,21 @@ public partial class LibraryViewModel : BaseViewModel, IQueryAttributable
     /////////////////////////////////////////////////////////////////////////////////
     // Methods
     /////////////////////////////////////////////////////////////////////////////////
-    public LibraryViewModel(IDataService dataService, IPopupService popupService)
+    public LibraryViewModel(IDataService dataService, IPopupService popupService, ILogger<LibraryViewModel> logger)
     {
+        if (logger != null)
+            _logger = logger;
+        else
+        {
+            #region debug_logger
+#if DEBUG
+            Debug.WriteLine("Null exception in NoteViewModel constructor: ILogger<NoteViewModel>");
+#endif
+            #endregion
+
+            throw new ArgumentNullException(nameof(logger));
+        }
+
         if (dataService != null)
             _dataService = dataService;
         else
@@ -50,6 +66,8 @@ public partial class LibraryViewModel : BaseViewModel, IQueryAttributable
             #region debug_dataservice
 #if DEBUG
             Debug.WriteLine("Null exception in LibraryViewModel constructor: IDataService");
+#elif !DEBUG
+            _logger.LogCritical("Null exception in LibraryViewModel constructor: IDataService. Cannot continue.");
 #endif
             #endregion
 
@@ -63,6 +81,8 @@ public partial class LibraryViewModel : BaseViewModel, IQueryAttributable
             #region debug_popupservice
 #if DEBUG
             Debug.WriteLine("Null exception in LibraryViewModel constructor: IPopupService");
+#elif !DEBUG
+            _logger.LogCritical("Null exception in LibraryViewModel constructor: IPopupService. Cannot continue.");
 #endif
             #endregion
 

--- a/ViewModels/NoteViewModel.cs
+++ b/ViewModels/NoteViewModel.cs
@@ -16,6 +16,8 @@
 
 using CommunityToolkit.Maui.Core;
 using CornellPad.Services.Interfaces;
+using MetroLog;
+using Microsoft.Extensions.Logging;
 
 namespace CornellPad.ViewModels;
 
@@ -26,7 +28,7 @@ public partial class NoteViewModel : BaseViewModel
     /////////////////////////////////////////////////////////////////////////////////
     private readonly IDataService _dataService;
     private readonly IPopupService _popupService;
-
+    private readonly ILogger<NoteViewModel> _logger;
     private NoteModel _noteModel;
 
     public string WhatILearnedToday
@@ -65,10 +67,54 @@ public partial class NoteViewModel : BaseViewModel
     /////////////////////////////////////////////////////////////////////////////////
     // Methods
     /////////////////////////////////////////////////////////////////////////////////
-    public NoteViewModel(IDataService dataService, IPopupService popupService)
+    public NoteViewModel(IDataService dataService, IPopupService popupService, ILogger<NoteViewModel> logger)
     {
-        _dataService = dataService;
-        _popupService = popupService;
+        if (logger != null)
+            _logger = logger;
+        else
+        {
+            #region debug_logger
+#if DEBUG
+            Debug.WriteLine("Null exception in NoteViewModel constructor: ILogger<NoteViewModel>");
+#endif
+            #endregion
+
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (dataService != null)
+            _dataService = dataService;
+        else
+        {
+            #region debug_dataservice
+
+#if DEBUG
+            Debug.WriteLine("Null exception in NoteViewModel constructor: IDataService");
+#elif !DEBUG
+            _logger.LogCritical("Null exception in NoteViewModel constructor: IDataService");
+#endif
+
+            #endregion
+
+            throw new ArgumentNullException(nameof(dataService));
+        }
+
+        if (popupService != null)
+            _popupService = popupService;
+        else
+        {
+            #region debug_popupservice
+
+#if DEBUG
+            Debug.WriteLine("Null exception in NoteViewModel constructor: IPopupService");
+#elif !DEBUG
+            _logger.LogCritical("Null exception in NoteViewModel constructor: IPopupService");
+#endif
+
+            #endregion
+
+            throw new ArgumentNullException(nameof(popupService));
+        }
     }
 
     [RelayCommand]

--- a/ViewModels/Popups/CreateTopicViewModel.cs
+++ b/ViewModels/Popups/CreateTopicViewModel.cs
@@ -17,6 +17,8 @@
 using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.Views;
 using CornellPad.Popups;
+using MetroLog;
+using Microsoft.Extensions.Logging;
 
 namespace CornellPad.ViewModels.Popups;
 
@@ -25,8 +27,10 @@ public partial class CreateTopicViewModel : BaseViewModel
     /////////////////////////////////////////////////////////////////////////////////
     // Members & Member Mutators
     /////////////////////////////////////////////////////////////////////////////////
-    ResourceDictionary _glyphResourceDict;
     private IPopupService _popupService;
+    private readonly ILogger<CreateTopicViewModel> _logger;
+
+    ResourceDictionary _glyphResourceDict;
 
     // prevent a repopulate of the glyph collection, if no search occurred.
     bool _isSearchingGlyphLibrary;
@@ -52,9 +56,37 @@ public partial class CreateTopicViewModel : BaseViewModel
     /////////////////////////////////////////////////////////////////////////////////
     // Methods
     /////////////////////////////////////////////////////////////////////////////////
-    public CreateTopicViewModel(IPopupService popupService)
+    public CreateTopicViewModel(IPopupService popupService, ILogger<CreateTopicViewModel> logger)
     {
-        _popupService = popupService;
+        if (logger != null)
+            _logger = logger;
+        else
+        {
+            #region debug_logger
+#if DEBUG
+            Debug.WriteLine("Null exception in CreateTopicViewModel constructor: ILogger<CreateTopicViewModel>");
+#endif
+            #endregion
+
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (popupService != null)
+            _popupService = popupService;
+        else
+        {
+            #region debug_popupservice
+
+#if DEBUG
+            Debug.WriteLine("Null exception in CreateTopicViewModel constructor: IPopupService");
+#elif !DEBUG
+            _logger.LogCritical("Null exception in CreateTopicViewModel constructor: IPopupService");
+#endif
+
+            #endregion
+
+            throw new ArgumentNullException(nameof(popupService));
+        }
 
         Glyphs = new ObservableCollection<GlyphCollectionItem>();
         _isSearchingGlyphLibrary = false;

--- a/ViewModels/SelectLibraryViewModel.cs
+++ b/ViewModels/SelectLibraryViewModel.cs
@@ -15,6 +15,8 @@
  *******************************************************************/
 
 using CornellPad.Services.Interfaces;
+using MetroLog;
+using Microsoft.Extensions.Logging;
 
 namespace CornellPad.ViewModels;
 
@@ -24,6 +26,7 @@ public partial class SelectLibraryViewModel : BaseViewModel
     // Members & Member Mutators
     /////////////////////////////////////////////////////////////////////////////////
     private IDataService _dataService;
+    private readonly ILogger<SelectLibraryViewModel> _logger;
 
     public ObservableCollection<LibraryModel> Libraries { get; set; }
 
@@ -39,9 +42,39 @@ public partial class SelectLibraryViewModel : BaseViewModel
     /////////////////////////////////////////////////////////////////////////////////
     // Methods
     /////////////////////////////////////////////////////////////////////////////////
-    public SelectLibraryViewModel(IDataService dataService, LibraryViewModel libraryViewModel)
+    public SelectLibraryViewModel(IDataService dataService, LibraryViewModel libraryViewModel, ILogger<SelectLibraryViewModel> logger)
     {
-        _dataService = dataService;
+        if (logger != null)
+            _logger = logger;
+        else
+        {
+            #region debug_logger
+
+#if DEBUG
+            Debug.WriteLine("Null exception in SelectLibraryViewModel constructor: ILogger<SelectLibraryViewModel>");
+#endif
+
+            #endregion
+
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (dataService != null)
+            _dataService = dataService;
+        else
+        {
+            #region debug_dataservice
+
+#if DEBUG
+            Debug.WriteLine("Null exception in SelectLibraryViewModel constructor: IDataService");
+#elif !DEBUG
+            _logger.LogCritical("Null exception in SelectLibraryViewModel constructor: IDataService");
+#endif
+
+            #endregion
+
+            throw new ArgumentNullException(nameof(dataService));
+        }
 
         SelectedLibraryModel = _dataService.ReadLibraries().Where(lib => lib.Id == _dataService.ReadSettings().CurrentLibraryId).ToList()[0];
 

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -17,6 +17,8 @@
 using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.Storage;
 using CornellPad.Services.Interfaces;
+using MetroLog;
+using Microsoft.Extensions.Logging;
 
 namespace CornellPad.ViewModels;
 
@@ -27,6 +29,7 @@ public partial class SettingsViewModel : BaseViewModel
     /////////////////////////////////////////////////////////////////////////////////
     private IDataService _dataService;
     private IPopupService _popupService;
+    private readonly ILogger<SettingsViewModel> _logger;
 
     [ObservableProperty]
     bool isAdvancedDBSettingsExpanded;
@@ -61,11 +64,55 @@ public partial class SettingsViewModel : BaseViewModel
     /////////////////////////////////////////////////////////////////////////////////
     // Methods
     /////////////////////////////////////////////////////////////////////////////////
-    
-    public SettingsViewModel(IDataService dataService, IPopupService popupService)
+
+    public SettingsViewModel(IDataService dataService, IPopupService popupService, ILogger<SettingsViewModel> logger)
     {
-        _dataService = dataService;
-        _popupService = popupService;
+        if (logger != null)
+            _logger = logger;
+        else
+        {
+            #region debug_logger
+#if DEBUG
+            Debug.WriteLine("Null exception in SettingsViewModel constructor: ILogger<SettingsViewModel>");
+#endif
+            #endregion
+
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (dataService != null)
+            _dataService = dataService;
+        else
+        {
+            #region debug_dataservice
+
+#if DEBUG
+            Debug.WriteLine("Null exception in SettingsViewModel constructor: IDataService");
+#elif !DEBUG
+            _logger.LogCritical("Null exception in SettingsViewModel constructor: IDataService");
+#endif
+
+            #endregion
+
+            throw new ArgumentNullException(nameof(dataService));
+        }
+
+        if (popupService != null)
+            _popupService = popupService;
+        else
+        {
+            #region debug_popupservice
+
+#if DEBUG
+            Debug.WriteLine("Null exception in SettingsViewModel constructor: IPopupService");
+#elif !DEBUG
+            _logger.LogCritical("Null exception in SettingsViewModel constructor: IPopupService");
+#endif
+
+            #endregion
+
+            throw new ArgumentNullException(nameof(popupService));
+        }
 
         // These shouldn't be -1 if set correctly from the DBMS.
         PageSizeIndex = -1;

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -331,6 +331,8 @@ public partial class SettingsViewModel : BaseViewModel
                 #region BackupDB_Exception
 #if DEBUG
                 Debug.WriteLine(ex.Message);
+#elif !DEBUG
+                _logger.LogError("Exception calling _dataService.BackupDB in BackupDatabase method: {message}\n    Stack Trace: {trace}", ex.Message, ex.StackTrace);
 #endif
                 #endregion
 
@@ -343,11 +345,11 @@ public partial class SettingsViewModel : BaseViewModel
             #region FolderPickerResult_Exception
 #if DEBUG
             Debug.WriteLine(result.Exception.Message);
+#elif !DEBUG
+            _logger.LogError("Exception calling FolderPicker.PickAsync in BackupDatabase method: {message}\n    Stack Trace: {trace}", result.Exception.Message, result.Exception.StackTrace);
 #endif
             #endregion
 
-            Console.WriteLine(result.Exception.Message);
-            //Logger.Error(result.Exception.Message, result.Exception.StackTrace); // We NEED loggin in the app...this is stupid!
             await _popupService.ShowPopupAsync<ErrorWarningViewModel>(onPresenting: vm =>
             {
                 vm.Title = "Error: Invalid Choice";
@@ -389,6 +391,8 @@ public partial class SettingsViewModel : BaseViewModel
                 #region UnauthorizedAccessException_Debug
 #if DEBUG
                 Debug.WriteLine(uae.Message);
+#elif !DEBUG
+                _logger.LogWarning("Unauthorized Access exception calling File.Copy in RestoreDatabase method: {message}\n    Stack Trace: {trace}", uae.Message, uae.StackTrace);
 #endif
                 #endregion
             }
@@ -397,6 +401,8 @@ public partial class SettingsViewModel : BaseViewModel
                 #region PathTooLongException_Debug
 #if DEBUG
                 Debug.WriteLine(ptle.Message);
+#elif !DEBUG
+                _logger.LogWarning("Path Too Long exception calling File.Copy in RestoreDatabase method: {message}\n    Stack Trace: {trace}", ptle.Message, ptle.StackTrace);
 #endif
                 #endregion
             }
@@ -405,6 +411,8 @@ public partial class SettingsViewModel : BaseViewModel
                 #region DirectoryNotFoundException_Debug
 #if DEBUG
                 Debug.WriteLine(dnfe.Message);
+#elif !DEBUG
+                _logger.LogWarning("Directory Not Found exception calling File.Copy in RestoreDatabase method: {message}\n    Stack Trace: {trace}", dnfe.Message, dnfe.StackTrace);
 #endif
                 #endregion
             }
@@ -413,6 +421,8 @@ public partial class SettingsViewModel : BaseViewModel
                 #region FileNotFoundException_Debug
 #if DEBUG
                 Debug.WriteLine(fnfe.Message);
+#elif !DEBUG
+                _logger.LogWarning("File Not Found exception calling File.Copy in RestoreDatabase method: {message}\n    Stack Trace: {trace}", fnfe.Message, fnfe.StackTrace);
 #endif
                 #endregion
             }
@@ -421,12 +431,14 @@ public partial class SettingsViewModel : BaseViewModel
                 #region IOException_Debug
 #if DEBUG
                 Debug.WriteLine(ioe.Message);
+#elif !DEBUG
+                _logger.LogWarning("IO exception calling File.Copy in RestoreDatabase method: {message}\n    Stack Trace: {trace}", ioe.Message, ioe.StackTrace);
 #endif
                 #endregion
             }
-            catch
+            catch (Exception ex)
             {
-                // TODO: We need to inform the user that something unexpected has happened, and they should create a bug report with steps on how to reproduce this error.
+                _logger.LogWarning("Exception calling File.Copy in RestoreDatabase method: {message}\n    Stack Trace: {trace}", ex.Message, ex.StackTrace);
             }
 
             _dataService.OpenConnection();

--- a/ViewModels/TopicViewModel.cs
+++ b/ViewModels/TopicViewModel.cs
@@ -16,6 +16,8 @@
 
 using CommunityToolkit.Maui.Core;
 using CornellPad.Services.Interfaces;
+using MetroLog;
+using Microsoft.Extensions.Logging;
 
 namespace CornellPad.ViewModels;
 
@@ -26,6 +28,7 @@ public partial class TopicViewModel : BaseViewModel, IQueryAttributable
     /////////////////////////////////////////////////////////////////////////////////
     private IDataService _dataService;
     private IPopupService _popupService;
+    private readonly ILogger<TopicViewModel> _logger;
 
     private TopicModel _topicModel;
 
@@ -88,10 +91,54 @@ public partial class TopicViewModel : BaseViewModel, IQueryAttributable
     /////////////////////////////////////////////////////////////////////////////////
     // Methods
     /////////////////////////////////////////////////////////////////////////////////
-    public TopicViewModel(IDataService dataService, IPopupService popupService)
+    public TopicViewModel(IDataService dataService, IPopupService popupService, ILogger<TopicViewModel> logger)
     {
-        _dataService = dataService;
-        _popupService = popupService;
+        if (logger != null)
+            _logger = logger;
+        else
+        {
+            #region debug_logger
+#if DEBUG
+            Debug.WriteLine("Null exception in TopicViewModel constructor: ILogger<TopicViewModel>");
+#endif
+            #endregion
+
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (dataService != null)
+            _dataService = dataService;
+        else
+        {
+            #region debug_dataservice
+
+#if DEBUG
+            Debug.WriteLine("Null exception in TopicViewModel constructor: IDataService");
+#elif !DEBUG
+            _logger.LogCritical("Null exception in TopicViewModel constructor: IDataService");
+#endif
+
+            #endregion
+
+            throw new ArgumentNullException(nameof(dataService));
+        }
+
+        if (popupService != null)
+            _popupService = popupService;
+        else
+        {
+            #region debug_popupservice
+
+#if DEBUG
+            Debug.WriteLine("Null exception in TopicViewModel constructor: IPopupService");
+#elif !DEBUG
+            _logger.LogCritical("Null exception in TopicViewModel constructor: IPopupService");
+#endif
+
+            #endregion
+
+            throw new ArgumentNullException(nameof(popupService));
+        }
 
         Title = "Topic Summary";
     }


### PR DESCRIPTION
# Feature Overview
Adds the [MetroLog.Maui NuGet package](https://github.com/roubachof/MetroLog) to provide logging of warning, error, and critical events in release. This is meant to provide information from end-users to make future app support easier. Logs are created in the app's cache directory, so no extra permissions should be needed.

### Data Capture Strategy
No extraneous data is captured from the user; these are purely support-based log events to help in issue troubleshooting.

### Log Retention
Logs are retained for two (2) days, after which, MetroLog automatically deletes the log and creates a new one. It appears that MetroLog won't create a log file until there is an issue that needs to be logged (and we aren't using logging as a pseudo-stack trace), so there should be little-to-no storage impact from this log file retention strategy.

### Log Acquisition
While MetroLog.Maui does provide an option on mobile devices to shake the device to create a log page to display, this feature isn't being utilized. It could be revisited in the future, but the approach was chosen to provide as near to an identical experience across all platforms. Hopefully, this will also streamline the code base so we don't have to support features that only exist on some of the platforms.

The user on mobile will need to install a file browser allowing them to access system files. A page in the (future) Wiki will need to list the probable locations for the log file for each platform, to allow the user to navigate to the log file when issuing a bug report.