### PR TITLE
Flyout fix

### DIFF
--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -32,38 +32,6 @@
             Style="{DynamicResource AppHeaderLabel}"/>
     </Shell.TitleView>
 
-    <!--
-        On MacCatalyst, the label and image's location are swapped
-        end-over-end by default. This fixes that issue.
-        Also, we don't seem to get all of our Typographies.xaml data,
-        so some of the styling is hard-coded...this feels bad.
-    -->
-    <Shell.ItemTemplate>
-        <OnPlatform x:TypeArguments="DataTemplate">
-            <On Platform="MacCatalyst">
-                <DataTemplate>
-                    <Grid
-                        ColumnDefinitions="30, *"
-                        RowDefinitions="30"
-                        Margin="10, 0, 0, 8">
-                        <Image
-                            Source="{Binding FlyoutIcon}"
-                            Style="{DynamicResource FlyoutItemImageStyle}"
-                            Margin="0, 0, 8, 0"/>
-                        <Label
-                            Grid.Column="1"
-                            Text="{Binding Title}"
-                            Style="{DynamicResource FlyoutItemLabelStyle}"
-                            VerticalOptions="Center"
-
-                            FontFamily="CrimsonPro_600"
-                            FontSize="28"/>
-                    </Grid>
-                </DataTemplate>
-            </On>
-        </OnPlatform>
-    </Shell.ItemTemplate>
-
     <Shell.FlyoutHeader>
         <Border
             Style="{DynamicResource FlyoutHeaderBGBorder}">

--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -95,6 +95,41 @@
         </Grid>
     </Shell.FlyoutFooter>
 
+    <Shell.ItemTemplate>
+        <DataTemplate>
+            <Grid x:Name="FlyoutItemLayout"
+                HeightRequest="{OnPlatform 44, Android=50}"
+                ColumnSpacing="{OnPlatform WinUI=0}"
+                RowSpacing="{OnPlatform WinUI=0}">
+                <VisualStateManager.VisualStateGroups>
+                    <VisualStateGroupList>
+                        <VisualStateGroup x:Name="CommonStates">
+                            <VisualState x:Name="Normal">
+                                <VisualState.Setters>
+                                    <Setter Property="BackgroundColor"
+                                    Value="Transparent" />
+                                </VisualState.Setters>
+                            </VisualState>
+                        </VisualStateGroup>
+                    </VisualStateGroupList>
+                </VisualStateManager.VisualStateGroups>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="{OnPlatform Android=54, iOS=50, WinUI=Auto, MacCatalyst=Auto}" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Image x:Name="FlyoutItemImage"
+                   Source="{Binding FlyoutIcon}"
+                   Style="{DynamicResource FlyoutItemImageStyle}">
+                </Image>
+                <Label x:Name="FlyoutItemLabel"
+                   Grid.Column="1"
+                   Text="{Binding Title}"
+                   Style="{DynamicResource FlyoutItemLabelStyle}">
+                </Label>
+            </Grid>
+        </DataTemplate>
+    </Shell.ItemTemplate>
+
     <ShellContent
         Title="Library"
         ContentTemplate="{DataTemplate local:LibraryView}"

--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -76,7 +76,7 @@
 
     <Shell.FlyoutFooter>
         <Grid
-            ColumnDefinitions="Auto, 40, 40, 40"
+            ColumnDefinitions="{OnPlatform MacCatalyst='Auto, 50, 50, 50', Default='Auto, 40, 40, 40'}"
             RowDefinitions="60"
             HeightRequest="60">
 

--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -32,6 +32,38 @@
             Style="{DynamicResource AppHeaderLabel}"/>
     </Shell.TitleView>
 
+    <!--
+        On MacCatalyst, the label and image's location are swapped
+        end-over-end by default. This fixes that issue.
+        Also, we don't seem to get all of our Typographies.xaml data,
+        so some of the styling is hard-coded...this feels bad.
+    -->
+    <Shell.ItemTemplate>
+        <OnPlatform x:TypeArguments="DataTemplate">
+            <On Platform="MacCatalyst">
+                <DataTemplate>
+                    <Grid
+                        ColumnDefinitions="30, *"
+                        RowDefinitions="30"
+                        Margin="10, 0, 0, 8">
+                        <Image
+                            Source="{Binding FlyoutIcon}"
+                            Style="{DynamicResource FlyoutItemImageStyle}"
+                            Margin="0, 0, 8, 0"/>
+                        <Label
+                            Grid.Column="1"
+                            Text="{Binding Title}"
+                            Style="{DynamicResource FlyoutItemLabelStyle}"
+                            VerticalOptions="Center"
+
+                            FontFamily="CrimsonPro_600"
+                            FontSize="28"/>
+                    </Grid>
+                </DataTemplate>
+            </On>
+        </OnPlatform>
+    </Shell.ItemTemplate>
+
     <Shell.FlyoutHeader>
         <Border
             Style="{DynamicResource FlyoutHeaderBGBorder}">

--- a/Popups/CreateTopicPopup.xaml
+++ b/Popups/CreateTopicPopup.xaml
@@ -78,11 +78,23 @@
                                 Text="Select Glyph Set"
                                 Style="{DynamicResource ControlTitlesText}"/>
 
+                            <!--#region Picker-CollectinView-->
+                            
+                            <!--
+                                We use the Picker for most platforms, but on MacCatalyst, we are
+                                forced to use a CollectionView due to a bug in the Picker not
+                                responding to user activity when placed in a Popup.
+                            -->
                             <Border
-                                Style="{DynamicResource PickerBorder}">
+                                Style="{DynamicResource PickerBorder}"
+                                IsVisible="{OnPlatform MacCatalyst='False', Default='True'}">
+                                
                                 <Picker
                                     SelectedItem="{Binding SelectedGlyphLibrary}"
-                                    WidthRequest="{OnPlatform Android=140, iOS=140, Default=140}">
+                                    ItemsSource="{Binding GlyphLibraries}"
+                                    
+                                    WidthRequest="{OnPlatform Android=140, iOS=140, Default=140}"
+                                    IsVisible="{OnPlatform MacCatalyst='False', Default='True'}">
 
                                     <Picker.Behaviors>
                                         <toolkit:EventToCommandBehavior
@@ -90,16 +102,28 @@
                                             Command="{Binding GlyphLibrarySelectedCommand}"/>
                                     </Picker.Behaviors>
 
-                                    <Picker.ItemsSource>
-                                        <x:Array Type="{x:Type x:String}">
-                                            <x:String>FA Brands</x:String>
-                                            <x:String>FA Regular</x:String>
-                                            <x:String>FA Solid</x:String>
-                                        </x:Array>
-                                    </Picker.ItemsSource>
-
                                 </Picker>
+                                
                             </Border>
+
+                            <Border
+                                Style="{DynamicResource PickerBorder}"
+                                IsVisible="{OnPlatform MacCatalyst='True', Default='False'}">
+
+                                <CollectionView
+                                    SelectedItem="{Binding SelectedGlyphLibrary}"
+                                    ItemsSource="{Binding GlyphLibraries}"
+                                    
+                                    HeightRequest="33"
+                                    WidthRequest="{OnPlatform Android=140, iOS=140, Default=140}"
+                                    IsVisible="{OnPlatform MacCatalyst='True', Default='False'}"
+                                    
+                                    SelectionMode="Single"
+                                    SelectionChangedCommand="{Binding GlyphLibrarySelectedCommand}"/>
+
+                            </Border>
+                            
+                            <!--#endregion-->
 
                         </HorizontalStackLayout>
 

--- a/Resources/Styles/Styles.xaml
+++ b/Resources/Styles/Styles.xaml
@@ -1852,17 +1852,27 @@
         <Setter Property="Shell.FlyoutBackdrop" Value="{DynamicResource FlyoutBackdropBrush}"/>
     </Style>
 
-    <Style ApplyToDerivedTypes="True" Class="FlyoutItemLabelStyle" TargetType="Label">
+    <Style ApplyToDerivedTypes="True" x:Key="FlyoutItemLabelStyle" TargetType="Label">
         <Setter Property="FontFamily" Value="{AppThemeBinding Light={StaticResource AppHeader_LM_FontFamily}, Dark={StaticResource AppHeader_DM_FontFamily},Default={StaticResource AppHeader_VI_FontFamily}}"/>
         <Setter Property="FontSize" Value="{AppThemeBinding Light={StaticResource AppHeader_LM_FontSize}, Dark={StaticResource AppHeader_DM_FontSize},Default={StaticResource AppHeader_VI_FontSize}}"/>
         <Setter Property="FontAttributes" Value="{AppThemeBinding Light={StaticResource AppHeader_LM_FontAttributes}, Dark={StaticResource AppHeader_DM_FontAttributes},Default={StaticResource AppHeader_VI_FontAttributes}}"/>
         <Setter Property="CharacterSpacing" Value="{AppThemeBinding Light={StaticResource AppHeader_LM_CharacterSpacing}, Dark={StaticResource AppHeader_DM_CharacterSpacing},Default={StaticResource AppHeader_VI_CharacterSpacing}}"/>
+        
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource Grey_900},Default={StaticResource White}}"/>
+
+        <Setter Property="HorizontalOptions" Value="{OnPlatform Default=Fill, WinUI=Start}"/>
+        <Setter Property="HorizontalTextAlignment" Value="Start"/>
+        <Setter Property="VerticalTextAlignment" Value="Center"/>
     </Style>
 
-    <Style ApplyToDerivedTypes="True" Class="FlyoutItemImageStyle" TargetType="Image">
+    <Style ApplyToDerivedTypes="True" x:Key="FlyoutItemImageStyle" TargetType="Image">
+        <Setter Property="VerticalOptions" Value="Center"/>
+        <Setter Property="HorizontalOptions" Value="{OnPlatform Default=Center, WinUI=Start}"/>
+        
         <Setter Property="HeightRequest" Value="{OnPlatform Android=24, iOS=24, WinUI=28, MacCatalyst=28}"/>
         <Setter Property="WidthRequest" Value="{OnPlatform Android=24, iOS=24, WinUI=28, MacCatalyst=28}"/>
+        
+        <Setter Property="Margin" Value="{OnPlatform 5, WinUI='12, 0, 12, 0'}"/>
     </Style>
 
     

--- a/Resources/Styles/Styles.xaml
+++ b/Resources/Styles/Styles.xaml
@@ -211,7 +211,8 @@
     <Style x:Key="FlyoutHeaderBGBorder" TargetType="Border">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource Secondary_300}, Dark={StaticResource Secondary_900},Default={StaticResource Neutral_Dark}}"/>
         <Setter Property="StrokeThickness" Value="0"/>
-        <Setter Property="HeightRequest" Value="162"/>
+        <Setter Property="HeightRequest" Value="{OnPlatform MacCatalyst='182', Default='162'}"/>
+        <Setter Property="Margin" Value="{OnPlatform MacCatalyst='0, 0, 0, 20', Default='0'}"/>
     </Style>
 
     <Style x:Key="FlyoutHeaderLogoBorder" TargetType="Border">
@@ -220,6 +221,7 @@
         <Setter Property="StrokeThickness" Value="0"/>
         <Setter Property="HeightRequest" Value="78"/>
         <Setter Property="WidthRequest" Value="78"/>
+        <Setter Property="Margin" Value="{OnPlatform MacCatalyst='0, 54, 0, 0', Default='0'}"/>
     </Style>
 
     <!-- ### Glyph Border Definitions ### -->

--- a/Resources/Styles/StylesVI.xaml
+++ b/Resources/Styles/StylesVI.xaml
@@ -210,7 +210,8 @@
     <Style x:Key="FlyoutHeaderBGBorder" TargetType="Border">
         <Setter Property="Background" Value="{StaticResource Neutral_Dark}"/>
         <Setter Property="StrokeThickness" Value="0"/>
-        <Setter Property="HeightRequest" Value="162"/>
+        <Setter Property="HeightRequest" Value="{OnPlatform MacCatalyst='182', Default='162'}"/>
+        <Setter Property="Margin" Value="{OnPlatform MacCatalyst='0,0,0,20', Default='0'}"/>
     </Style>
 
     <Style x:Key="FlyoutHeaderLogoBorder" TargetType="Border">
@@ -219,6 +220,7 @@
         <Setter Property="StrokeThickness" Value="0"/>
         <Setter Property="HeightRequest" Value="78"/>
         <Setter Property="WidthRequest" Value="78"/>
+        <Setter Property="Margin" Value="{OnPlatform MacCatalyst='0, 54, 0, 0', Default='0'}"/>
     </Style>
 
     <!-- ### Glyph Border Definitions ### -->

--- a/Resources/Styles/StylesVI.xaml
+++ b/Resources/Styles/StylesVI.xaml
@@ -1768,18 +1768,27 @@
         <Setter Property="Shell.FlyoutBackdrop" Value="{DynamicResource VIFlyoutBackdropBrush}"/>
     </Style>
 
-    <Style ApplyToDerivedTypes="True" Class="FlyoutItemLabelStyle" TargetType="Label">
+    <Style ApplyToDerivedTypes="True" x:Key="FlyoutItemLabelStyle" TargetType="Label">
         <Setter Property="FontFamily" Value="{StaticResource AppHeader_VI_FontFamily}"/>
         <Setter Property="FontSize" Value="{StaticResource AppHeader_VI_FontSize}"/>
         <Setter Property="FontAttributes" Value="{StaticResource AppHeader_VI_FontAttributes}"/>
         <Setter Property="CharacterSpacing" Value="{StaticResource AppHeader_VI_CharacterSpacing}"/>
-        
+
         <Setter Property="TextColor" Value="{StaticResource White}"/>
+
+        <Setter Property="HorizontalOptions" Value="{OnPlatform Default=Fill, WinUI=Start}"/>
+        <Setter Property="HorizontalTextAlignment" Value="Start"/>
+        <Setter Property="VerticalTextAlignment" Value="Center"/>
     </Style>
 
-    <Style ApplyToDerivedTypes="True" Class="FlyoutItemImageStyle" TargetType="Image">
+    <Style ApplyToDerivedTypes="True" x:Key="FlyoutItemImageStyle" TargetType="Image">
+        <Setter Property="VerticalOptions" Value="Center"/>
+        <Setter Property="HorizontalOptions" Value="{OnPlatform Default=Center, WinUI=Start}"/>
+        
         <Setter Property="HeightRequest" Value="{OnPlatform Android=24, iOS=24, WinUI=28, MacCatalyst=28}"/>
         <Setter Property="WidthRequest" Value="{OnPlatform Android=24, iOS=24, WinUI=28, MacCatalyst=28}"/>
+
+        <Setter Property="Margin" Value="{OnPlatform 5, WinUI='12, 0, 12, 0'}"/>
     </Style>
 
 

--- a/Resources/Styles/Typographies.xaml
+++ b/Resources/Styles/Typographies.xaml
@@ -50,7 +50,7 @@
     <!--#region AppHeader_VI font definitions -->
     <x:String x:Key="AppHeader_VI_FontFamily">SourceSansPro_Bold</x:String>
     <x:Double x:Key="AppHeader_VI_FontSize">28</x:Double>
-    <x:Double x:Key="AppHeader_VI_CharacterSpacing">1</x:Double>
+    <x:Double x:Key="AppHeader_VI_CharacterSpacing">0.5</x:Double>
     <FontAttributes x:Key="AppHeader_VI_FontAttributes">Bold</FontAttributes>
     <!--#endregion-->
 
@@ -106,7 +106,7 @@
     <!--#region CardSubtitleItalic_VI font definitions -->
     <x:String x:Key="CardSubtitleItalic_VI_FontFamily">CrimsonPro_Italic</x:String>
     <x:Double x:Key="CardSubtitleItalic_VI_FontSize">20</x:Double>
-    <x:Double x:Key="CardSubtitleItalic_VI_CharacterSpacing">1</x:Double>
+    <x:Double x:Key="CardSubtitleItalic_VI_CharacterSpacing">0.5</x:Double>
     <FontAttributes x:Key="CardSubtitleItalic_VI_FontAttributes">Bold</FontAttributes>
     <!--#endregion-->
 
@@ -148,7 +148,7 @@
     <!--#region CardTitle_VI font definitions -->
     <x:String x:Key="CardTitle_VI_FontFamily">SourceSansPro_Bold</x:String>
     <x:Double x:Key="CardTitle_VI_FontSize">28</x:Double>
-    <x:Double x:Key="CardTitle_VI_CharacterSpacing">1</x:Double>
+    <x:Double x:Key="CardTitle_VI_CharacterSpacing">0.5</x:Double>
     <FontAttributes x:Key="CardTitle_VI_FontAttributes">Bold</FontAttributes>
     <!--#endregion-->
 

--- a/ViewModels/Popups/CreateTopicViewModel.cs
+++ b/ViewModels/Popups/CreateTopicViewModel.cs
@@ -53,6 +53,9 @@ public partial class CreateTopicViewModel : BaseViewModel
     [ObservableProperty]
     string _searchGlyphLibrary;
 
+    [ObservableProperty]
+    ObservableCollection<string> _glyphLibraries;
+
     /////////////////////////////////////////////////////////////////////////////////
     // Methods
     /////////////////////////////////////////////////////////////////////////////////
@@ -90,6 +93,11 @@ public partial class CreateTopicViewModel : BaseViewModel
 
         Glyphs = new ObservableCollection<GlyphCollectionItem>();
         _isSearchingGlyphLibrary = false;
+
+        GlyphLibraries = new ObservableCollection<string>();
+        GlyphLibraries.Add("FA Brands");
+        GlyphLibraries.Add("FA Regular");
+        GlyphLibraries.Add("FA Solid");
     }
 
     [RelayCommand]


### PR DESCRIPTION
Originally meant solely to fix the flyout menu on MacCatalyst, this led to several other fixes in the UI for both MacCatalyst as well as Android.

MacCatalyst: Adds a data template for the ShellItem to unify the appearance of the flyout menu across the supported platforms, as MacCatalyst was displaying the label text first, and then the icon. This change turned out to also be necessary to facilitate the changes that were needed to the resource dictionaries `Styles.xaml` and `StylesVI.xaml`, which fixes the crash on Android.

Android: Changes to the resource dictionaries `Styles.xaml` and `StylesVI.xaml` were required; apparently, we can no longer override a predefined style with the `Class` parameter. Doing so was causing a `System.Collections.Generic.KeyNotFoundException` exception for the key `Microsoft.Maui.Controls.SetterSpecificity` on Android (API 29 and 33 where tested in the emulator).

A small tweak was made to the `Typographies.xaml` resource dictionary. Due to their character spacing, card title elements were stretching off-screen even though they were within the self-imposed character limit length (this needs to be implemented in code, but has yet to be).